### PR TITLE
Clean up buildspec by removing unnecessary commands

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,15 +1,6 @@
 version: 0.2
 
 phases:
-  pre_build:
-    commands:
-      - echo Installing CI/CD Dependencies...
-      - python -m venv venv
-      - echo "source venv/bin/activate" > activate.sh
-      - bash activate.sh
-      - python -m pip install --upgrade pip
-      - python -m pip install pytest pytest-astropy pytest-cov
-
   build:
     commands:
     - REGION=us-east-1

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,16 +9,6 @@ phases:
       - bash activate.sh
       - python -m pip install --upgrade pip
       - python -m pip install pytest pytest-astropy pytest-cov
-      - pip3 install -r requirements.txt
-      - echo ________________________________
-
-      - echo Linting with Black...
-      - black --check --diff lambda_function/
-      - echo ________________________________
-      
-      - echo Linting with Flake...
-      - flake8 --count --max-line-length 100 lambda_function/
-      - echo ________________________________
 
   build:
     commands:

--- a/lambda_function/Dockerfile
+++ b/lambda_function/Dockerfile
@@ -7,11 +7,7 @@ FROM ${BASE_IMAGE}
 ARG ROOT="/"
 ARG FUNCTION_DIR="/lambda_function/"
 
-# Set default values for requirements file
-ARG REQUIREMENTS_FILE="hermes-requirements.txt"
-
-# Copy requirements file to root directory
-COPY ${REQUIREMENTS_FILE} ${ROOT}requirements.txt 
+COPY requirements.txt ${ROOT}
 
 # Update pip and install setuptools
 RUN pip install --upgrade pip setuptools

--- a/lambda_function/hermes-requirements.txt
+++ b/lambda_function/hermes-requirements.txt
@@ -1,5 +1,0 @@
-sdc_aws_utils @ git+https://github.com/swxsoc/sdc_aws_utils.git
-hermes_spani @ git+https://github.com/HERMES-SOC/hermes_spani.git
-hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git
-hermes_nemisis @ git+https://github.com/HERMES-SOC/hermes_nemisis.git
-hermes_merit @ git+https://github.com/HERMES-SOC/hermes_merit.git

--- a/lambda_function/impax-requirements.txt
+++ b/lambda_function/impax-requirements.txt
@@ -1,5 +1,0 @@
-sdc_aws_utils @ git+https://github.com/swxsoc/sdc_aws_utils.git
-metatracker @ git+https://github.com/swxsoc/MetaTracker.git
-impax_craft @ git+https://github.com/iMPAXSat/impax_craft.git
-impax_iaxis @ git+https://github.com/iMPAXSat/impax_iaxis.git
-impax_ifire @ git+https://github.com/iMPAXSat/impax_ifire.git

--- a/lambda_function/padre-requirements.txt
+++ b/lambda_function/padre-requirements.txt
@@ -1,3 +1,0 @@
-sdc_aws_utils @ git+https://github.com/swxsoc/sdc_aws_utils.git
-padre_meddea @ git+https://github.com/PADRESat/padre_meddea.git
-padre_sharp @ git+https://github.com/PADRESat/padre_sharp.git

--- a/lambda_function/requirements.txt
+++ b/lambda_function/requirements.txt
@@ -1,0 +1,1 @@
+sdc_aws_utils @ git+https://github.com/swxsoc/sdc_aws_utils.git

--- a/lambda_function/swxsoc_pipeline-requirements.txt
+++ b/lambda_function/swxsoc_pipeline-requirements.txt
@@ -1,3 +1,0 @@
-sdc_aws_utils @ git+https://github.com/swxsoc/sdc_aws_utils.git
-metatracker @ git+https://github.com/swxsoc/MetaTracker.git
-swxsoc_reach @ git+https://github.com/swxsoc/swxsoc_reach.git


### PR DESCRIPTION
- Remove Pre-Build steps from CodeBuild. Removed pip install for requirements and linting commands.
- Removed mission-specific requirements.txt files, substituting for a single, shared file.
- Update Dockerfile to build similar to Sorting Lambda without mission-specific requirements. 